### PR TITLE
Fix pygame freeze in visual RL mode

### DIFF
--- a/train_agents.py
+++ b/train_agents.py
@@ -61,8 +61,14 @@ def train(algo_name: str, timesteps: int, logdir: str, render_mode: str):
         device=device,
     )
 
-    model.learn(total_timesteps=timesteps, callback=callbacks)
-    model.save(os.path.join(logdir, f"{algo_name}_final"))
+    try:
+        model.learn(total_timesteps=timesteps, callback=callbacks)
+    except KeyboardInterrupt:
+        print("Training interrupted. Saving model...")
+    finally:
+        model.save(os.path.join(logdir, f"{algo_name}_final"))
+        env.close()
+        eval_env.close()
 
 
 def main():


### PR DESCRIPTION
## Summary
- handle pygame events when training agents
- reuse visualizer instead of recreating it on env reset
- degrade gracefully to headless mode if the window is closed
- save model and close envs on keyboard interrupt during training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e77f1aac8322ab947424294f3f6b