### PR TITLE
Add episode termination and training improvements

### DIFF
--- a/docs/rl_env.md
+++ b/docs/rl_env.md
@@ -25,3 +25,6 @@ The reward is based on incremental production with efficiency bonuses and queue 
 reward = (delta_waste + 2 * delta_mineral) + fleet_utilisation - 0.1 * queue_penalty
 ```
 This favours mineral production and keeps the fleet working while discouraging long queues.
+
+## Episode Termination
+Episodes end when either a production target or a step limit is reached. By default the environment terminates after accumulating **400t** of total throughput or **800** steps, whichever happens first. These values can be customised via the `max_steps` and `target_production` parameters when creating the environment.

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,6 +5,7 @@ from stable_baselines3.common.env_checker import check_env
 sys.path.append(".")
 from rl.mining_env import MiningEnv
 
+
 class EnvTest(unittest.TestCase):
     def test_env_valid(self):
         env = MiningEnv()
@@ -12,6 +13,19 @@ class EnvTest(unittest.TestCase):
         obs, info = env.reset()
         self.assertEqual(obs.shape[0], env.observation_space.shape[0])
         env.close()
+
+    def test_env_terminates(self):
+        env = MiningEnv(max_steps=5, target_production=10)
+        env.reset()
+        done = False
+        for _ in range(10):
+            _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+            if terminated or truncated:
+                done = True
+                break
+        env.close()
+        self.assertTrue(done)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `max_steps` and `target_production` parameters in `MiningEnv`
- add termination logic and info metrics
- log throughput and utilisation in TensorBoard via callback
- adjust training defaults (evaluation frequency, n eval episodes, checkpoints)
- document episode termination in `docs/rl_env.md`
- test that environment terminates properly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f6b9198c8322a464b86d3f1aec98