### PR TITLE
Add new trucks and update observation size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ El único elemento controlable del simulador es **la asignación de destinos de 
 ### Componentes Principales
 
 #### **Equipos Móviles**
-- **Trucks (Camiones)**: Flota de 6 camiones CAT 797 con capacidades de 200t
+- **Trucks (Camiones)**: Flota de 20 camiones (6 de 200t y 14 de 180t) con eficiencia individual
   - Estados: `waiting_assignment`, `moving_to_shovel`, `loading`, `moving_to_dump`, `dumping`, `returning`
   - Atributos: efficiency (0.75-0.90), velocidad variable por segmento
   - Control de tráfico: distancia mínima entre camiones (30m)
@@ -141,7 +141,7 @@ mining_simulation/
 
 ### Environment: `MiningEnv`
 
-**Observation Space** (54 dimensiones normalizadas):
+**Observation Space** (124 dimensiones normalizadas):
 - Estado global: tick, producción total, camiones disponibles
 - Colas y estado de crusher, dump y palas
 - Estado detallado de cada camión (task, carga, eficiencia, distancias)
@@ -274,7 +274,7 @@ for _ in range(1000):
 ## ✅ Funcionalidades Implementadas
 
 ### **Sistema de Simulación Completo**
-- [x] Modelado realista de equipos mineros (6 camiones, 6 palas, crusher, dump)
+- [x] Modelado realista de equipos mineros (20 camiones, 6 palas, crusher, dump)
 - [x] Red vial con 25 nodos y velocidades diferenciadas por tipo de ruta
 - [x] Control de tráfico y distancias mínimas entre camiones (30m)
 - [x] Gestión de colas FIFO con capacidades limitadas por equipo
@@ -290,7 +290,7 @@ for _ in range(1000):
 - [x] Leyenda completa y controles interactivos
 
 ### **Sistema de Reinforcement Learning**
-- [x] Environment Gymnasium compatible (`MiningEnv`) con observation space de 54 dimensiones
+- [x] Environment Gymnasium compatible (`MiningEnv`) con observation space de 124 dimensiones
 - [x] Action space discreto (9 acciones) con action masking inteligente
 - [x] Función de recompensa balanceada: producción + utilización - penalización de colas
 - [x] Script de entrenamiento completo con PPO, A2C, DQN

--- a/core/fms_manager.py
+++ b/core/fms_manager.py
@@ -18,6 +18,7 @@ class FMSManager:
         self.dijkstra = Dijkstra(self.map.nodes)
 
         # Crear flota de camiones
+        # Los primeros 6 mantienen las especificaciones originales
         self.trucks = [
             Truck(1, 200, self.map.nodes["parking"], efficiency=0.85),
             Truck(2, 200, self.map.nodes["parking"], efficiency=0.75),
@@ -25,6 +26,22 @@ class FMSManager:
             Truck(4, 200, self.map.nodes["parking"], efficiency=0.88),
             Truck(5, 200, self.map.nodes["parking"], efficiency=0.82),
             Truck(6, 200, self.map.nodes["parking"], efficiency=0.78),
+
+            # Nuevos camiones con mayor eficiencia y 180t de capacidad
+            Truck(7, 180, self.map.nodes["parking"], efficiency=0.91),
+            Truck(8, 180, self.map.nodes["parking"], efficiency=0.92),
+            Truck(9, 180, self.map.nodes["parking"], efficiency=0.93),
+            Truck(10, 180, self.map.nodes["parking"], efficiency=0.94),
+            Truck(11, 180, self.map.nodes["parking"], efficiency=0.95),
+            Truck(12, 180, self.map.nodes["parking"], efficiency=0.96),
+            Truck(13, 180, self.map.nodes["parking"], efficiency=0.97),
+            Truck(14, 180, self.map.nodes["parking"], efficiency=0.98),
+            Truck(15, 180, self.map.nodes["parking"], efficiency=0.99),
+            Truck(16, 180, self.map.nodes["parking"], efficiency=1.00),
+            Truck(17, 180, self.map.nodes["parking"], efficiency=1.01),
+            Truck(18, 180, self.map.nodes["parking"], efficiency=1.02),
+            Truck(19, 180, self.map.nodes["parking"], efficiency=1.03),
+            Truck(20, 180, self.map.nodes["parking"], efficiency=1.04),
         ]
 
         # Crear palas

--- a/rl/mining_env.py
+++ b/rl/mining_env.py
@@ -74,8 +74,8 @@ class MiningEnv(gym.Env):
         if self.render_mode == "visual":
             self._init_pygame()
 
-        # Observation space: extended 54-dimensional vector
-        self.obs_dim = 54
+        # Observation space dimension based on fleet size
+        self.obs_dim = len(self.manager.get_extended_observation_vector())
         obs_low = np.zeros(self.obs_dim, dtype=np.float32)
         obs_high = np.ones(self.obs_dim, dtype=np.float32) * np.inf
         self.observation_space = gym.spaces.Box(
@@ -124,6 +124,13 @@ class MiningEnv(gym.Env):
         super().reset(seed=seed)
         # Recreate manager to reset state
         self.manager = FMSManager()
+        # Recompute observation space in case fleet size changed
+        self.obs_dim = len(self.manager.get_extended_observation_vector())
+        self.observation_space = gym.spaces.Box(
+            low=np.zeros(self.obs_dim, dtype=np.float32),
+            high=np.ones(self.obs_dim, dtype=np.float32) * np.inf,
+            dtype=np.float32,
+        )
         self.step_count = 0
         if self.visualizer:
             # Reuse existing visualizer instance with new manager


### PR DESCRIPTION
## Summary
- expand fleet with 14 additional high‑efficiency trucks
- compute observation size dynamically in `MiningEnv`
- document new fleet size and updated observation space

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872fcaac0848322bd81f001a4c6b2df