### PR TITLE
Add hang time and wrong dumping penalties

### DIFF
--- a/core/crusher.py
+++ b/core/crusher.py
@@ -9,6 +9,8 @@ class Crusher:
         self.current_truck = None
         self.timer = 0
         self.total_processed = 0
+        # Track waste incorrectly dumped here
+        self.total_waste_dumped = 0
         
     def update(self):
         if not self.current_truck and self.queue:
@@ -22,7 +24,9 @@ class Crusher:
                 # Procesar material
                 if self.current_truck.material_type == 'mineral':
                     self.total_processed += self.current_truck.current_load
-                    
+                else:
+                    self.total_waste_dumped += self.current_truck.current_load
+
                 self.current_truck.finish_dumping()
                 self.current_truck = None
                 

--- a/core/dump.py
+++ b/core/dump.py
@@ -3,11 +3,13 @@ class Dump:
     def __init__(self, node, process_time=4):
         self.node = node
         self.process_time = process_time
-        
+
         self.queue = []
         self.current_truck = None
         self.timer = 0
         self.total_dumped = 0
+        # Track mineral incorrectly dumped here
+        self.total_mineral_dumped = 0
         
     def update(self):
         if not self.current_truck and self.queue:
@@ -19,7 +21,10 @@ class Dump:
             self.timer -= 1
             if self.timer <= 0:
                 # Registrar material descargado
-                self.total_dumped += self.current_truck.current_load
+                if self.current_truck.material_type == 'waste':
+                    self.total_dumped += self.current_truck.current_load
+                else:
+                    self.total_mineral_dumped += self.current_truck.current_load
                 self.current_truck.finish_dumping()
                 self.current_truck = None
                 

--- a/core/shovel.py
+++ b/core/shovel.py
@@ -26,9 +26,14 @@ class Shovel:
         self.timer = 0
         self.passes_required = 0
         self.passes_done = 0
+        # Tiempo que la pala permanece inactiva sin camiones
+        self.hang_time = 0
         
     def update(self):
         """Process loading logic for the shovel."""
+        if not self.current_truck and not self.queue:
+            # Shovel idle without trucks
+            self.hang_time += 1
         if not self.current_truck and self.queue:
             # Start loading the next truck in queue
             self.current_truck = self.queue.pop(0)

--- a/docs/rl_env.md
+++ b/docs/rl_env.md
@@ -20,11 +20,16 @@ A discrete action chooses among nine high level commands:
 Invalid actions are masked via the `action_mask` entry in `info`.
 
 ## Reward
-The reward is based on incremental production with efficiency bonuses and queue penalties:
+The reward is based on incremental production with efficiency bonuses and several penalties:
 ```
-reward = (delta_waste + 2 * delta_mineral) + fleet_utilisation - 0.1 * queue_penalty
+reward = (delta_waste + 2 * delta_mineral)
+         + fleet_utilisation
+         - 0.1 * queue_penalty
+         - 0.5 * delta_hang_time
+         - 2.0 * delta_mineral_lost
+         - 1.0 * delta_waste_in_crusher
 ```
-This favours mineral production and keeps the fleet working while discouraging long queues.
+This favours mineral production, keeps the fleet working and penalises idle shovels or incorrect dumping of material.
 
 ## Episode Termination
 Episodes end when either a production target or a step limit is reached. By default the environment terminates after accumulating **400t** of total throughput or **800** steps, whichever happens first. These values can be customised via the `max_steps` and `target_production` parameters when creating the environment.

--- a/rl/mining_env.py
+++ b/rl/mining_env.py
@@ -89,6 +89,9 @@ class MiningEnv(gym.Env):
         self.running_stats = RunningStats(self.obs_dim)
         self.last_processed = 0.0
         self.last_dumped = 0.0
+        self.last_mineral_lost = 0.0
+        self.last_waste_wrong = 0.0
+        self.last_hang_time = 0.0
 
     def _init_pygame(self):
         """Initialize pygame and the visualizer."""
@@ -138,6 +141,9 @@ class MiningEnv(gym.Env):
         self.running_stats = RunningStats(self.obs_dim)
         self.last_processed = 0.0
         self.last_dumped = 0.0
+        self.last_mineral_lost = 0.0
+        self.last_waste_wrong = 0.0
+        self.last_hang_time = 0.0
         obs = self._get_observation()
         info = {"action_mask": self.valid_action_mask}
         return obs, info
@@ -184,6 +190,9 @@ class MiningEnv(gym.Env):
             "fleet_utilization": np.mean(
                 [1.0 if not t.is_available() else 0.0 for t in self.manager.trucks]
             ),
+            "lost_mineral": self.manager.dump.total_mineral_dumped,
+            "waste_in_crusher": self.manager.crusher.total_waste_dumped,
+            "hang_time": sum(s.hang_time for s in self.manager.shovels),
         }
         return obs, reward, terminated, truncated, info
 
@@ -214,8 +223,15 @@ class MiningEnv(gym.Env):
         """Balanced reward with production deltas and penalties."""
         delta_mineral = self.manager.crusher.total_processed - self.last_processed
         delta_waste = self.manager.dump.total_dumped - self.last_dumped
+        delta_lost = self.manager.dump.total_mineral_dumped - self.last_mineral_lost
+        delta_wrong = self.manager.crusher.total_waste_dumped - self.last_waste_wrong
+        delta_hang = sum(s.hang_time for s in self.manager.shovels) - self.last_hang_time
+
         self.last_processed = self.manager.crusher.total_processed
         self.last_dumped = self.manager.dump.total_dumped
+        self.last_mineral_lost = self.manager.dump.total_mineral_dumped
+        self.last_waste_wrong = self.manager.crusher.total_waste_dumped
+        self.last_hang_time = sum(s.hang_time for s in self.manager.shovels)
 
         production = delta_waste + 2.0 * delta_mineral
 
@@ -227,7 +243,11 @@ class MiningEnv(gym.Env):
             + len(self.manager.dump.queue)
             + sum(len(s.queue) for s in self.manager.shovels)
         )
-        return production + working - 0.1 * queue_penalty
+        penalty = 0.1 * queue_penalty
+        penalty += 0.5 * delta_hang
+        penalty += 2.0 * delta_lost
+        penalty += 1.0 * delta_wrong
+        return production + working - penalty
 
     def _get_observation(self) -> np.ndarray:
         raw_obs = np.array(

--- a/train_agents.py
+++ b/train_agents.py
@@ -31,10 +31,19 @@ class TensorboardMetricsCallback(BaseCallback):
             info = infos[0]
             throughput = info.get("throughput")
             util = info.get("fleet_utilization")
+            lost = info.get("lost_mineral")
+            wrong = info.get("waste_in_crusher")
+            hang = info.get("hang_time")
             if throughput is not None:
                 self.logger.record("rollout/throughput", float(throughput))
             if util is not None:
                 self.logger.record("rollout/utilization", float(util))
+            if lost is not None:
+                self.logger.record("rollout/lost_mineral", float(lost))
+            if wrong is not None:
+                self.logger.record("rollout/waste_in_crusher", float(wrong))
+            if hang is not None:
+                self.logger.record("rollout/hang_time", float(hang))
         return True
 
 


### PR DESCRIPTION
## Summary
- track mineral dumping losses and waste into crusher
- accumulate shovel idle time
- penalize hang time and incorrect dumps in reward function
- expose custom metrics via `info` and TensorBoard callback
- document updated reward formula

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730e3814e4832291b95485add168ea