### PR TITLE
Add checkpoint resume capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ python train_agents.py --algo ppo --timesteps 100000 --mode headless
 python train_agents.py --algo ppo --timesteps 10000 --mode visual
 ```
 
+**Retomar desde un checkpoint:**
+```bash
+python train_agents.py --algo ppo --timesteps 50000 --resume-from training_logs/checkpoints
+```
+
 **Algoritmos disponibles:**
 - **PPO**: Proximal Policy Optimization (recomendado)
 - **A2C**: Advantage Actor-Critic
@@ -187,6 +192,7 @@ python train_agents.py --algo ppo --timesteps 10000 --mode visual
 - Early stopping si no hay mejora en 5 evaluaciones
 - Logs de TensorBoard para métricas personalizadas
 - Guardado automático del mejor modelo
+- Retomar entrenamiento desde un checkpoint con `--resume-from`
 
 ### Monitoreo con TensorBoard
 
@@ -302,6 +308,7 @@ for _ in range(1000):
 - [x] Callbacks de evaluación automática cada 5k timesteps
 - [x] Checkpoints automáticos y early stopping
 - [x] Integración completa con TensorBoard para monitoreo
+- [x] Capacidad de reanudar entrenamientos desde checkpoints
 
 ### **Validación y Testing**
 - [x] Environment validation con `stable_baselines3.common.env_checker`

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,19 @@
+import os
+import shutil
+import unittest
+
+from train_agents import train
+
+
+class ResumeTest(unittest.TestCase):
+    def test_resume_from_model(self):
+        logdir = "test_logs"
+        train("ppo", timesteps=2, logdir=logdir, render_mode="headless")
+        model_path = os.path.join(logdir, "ppo_final.zip")
+        self.assertTrue(os.path.exists(model_path))
+        train("ppo", timesteps=1, logdir=logdir, render_mode="headless", resume_from=model_path)
+        shutil.rmtree(logdir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow loading saved models in `train_agents.py`
- document how to resume training from checkpoints in README
- support training resume in features list
- add regression test for resume

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687316cf02d48322a2356314a6122908