### PR TITLE
Streamline PPO training

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,28 +168,25 @@ reward = (delta_waste + 2 * delta_mineral) + fleet_utilisation - 0.1 * queue_pen
 
 **Entrenar con PPO (recomendado):**
 ```bash
-python train_agents.py --algo ppo --timesteps 100000 --mode headless
+python train_agents.py --timesteps 100000 --mode headless
 ```
 
 **Entrenar con visualización (debug):**
 ```bash
-python train_agents.py --algo ppo --timesteps 10000 --mode visual
+python train_agents.py --timesteps 10000 --mode visual
 ```
 
 **Retomar desde un checkpoint:**
 ```bash
-python train_agents.py --algo ppo --timesteps 50000 --resume-from training_logs/checkpoints
+python train_agents.py --timesteps 50000 --resume-from training_logs/checkpoints
 ```
 
-**Algoritmos disponibles:**
+**Algoritmo disponible:**
 - **PPO**: Proximal Policy Optimization (recomendado)
-- **A2C**: Advantage Actor-Critic
-- **DQN**: Deep Q-Network
 
 **Características del entrenamiento:**
 - Evaluación cada 5,000 timesteps
 - Checkpoints automáticos cada 10,000 timesteps
-- Early stopping si no hay mejora en 5 evaluaciones
 - Logs de TensorBoard para métricas personalizadas
 - Guardado automático del mejor modelo
 - Retomar entrenamiento desde un checkpoint con `--resume-from`
@@ -256,7 +253,7 @@ python main.py --visual
 
 ### **2. Entrenamiento de RL**
 ```bash
-python train_agents.py --algo ppo --timesteps 100000
+python train_agents.py --timesteps 100000
 ```
 - Desarrollo de políticas de asignación inteligentes
 - Comparación RL vs heurísticas tradicionales
@@ -304,9 +301,9 @@ for _ in range(1000):
 - [x] Environment Gymnasium compatible (`MiningEnv`) con observation space de 124 dimensiones
 - [x] Action space discreto (9 acciones) con action masking inteligente
 - [x] Función de recompensa balanceada: producción + utilización - penalización de colas
-- [x] Script de entrenamiento completo con PPO, A2C, DQN
+- [x] Script de entrenamiento con PPO
 - [x] Callbacks de evaluación automática cada 5k timesteps
-- [x] Checkpoints automáticos y early stopping
+- [x] Checkpoints automáticos
 - [x] Integración completa con TensorBoard para monitoreo
 - [x] Capacidad de reanudar entrenamientos desde checkpoints
 

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -8,10 +8,10 @@ from train_agents import train
 class ResumeTest(unittest.TestCase):
     def test_resume_from_model(self):
         logdir = "test_logs"
-        train("ppo", timesteps=2, logdir=logdir, render_mode="headless")
+        train(timesteps=2, logdir=logdir, render_mode="headless")
         model_path = os.path.join(logdir, "ppo_final.zip")
         self.assertTrue(os.path.exists(model_path))
-        train("ppo", timesteps=1, logdir=logdir, render_mode="headless", resume_from=model_path)
+        train(timesteps=1, logdir=logdir, render_mode="headless", resume_from=model_path)
         shutil.rmtree(logdir)
 
 


### PR DESCRIPTION
## Summary
- remove unused A2C and DQN code
- drop early stopping callback
- simplify CLI and tests to always train PPO
- update documentation to match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873391e52d88322ae89dc9c94428080