### PR TITLE
Fix deterministic evaluation

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -25,12 +25,19 @@ def evaluate(model_path: str, render_mode: str = "headless", steps: int = 1000):
     model = PPO.load(model_path)
     env = MiningEnv(render_mode=render_mode, max_steps=steps, target_production=40000)
     obs, _ = env.reset()
+    stats_path = model_path.replace(".zip", "_stats.npz")
+    if os.path.exists(stats_path):
+        env.load_running_stats_from_file(stats_path)
+        obs = env.get_normalised_observation()
 
     for _ in range(steps):
         action, _ = model.predict(obs, deterministic=True)
         obs, _, done, truncated, _ = env.step(action)
         if done or truncated:
             obs, _ = env.reset()
+            if os.path.exists(stats_path):
+                env.load_running_stats_from_file(stats_path)
+                obs = env.get_normalised_observation()
 
     env.close()
 

--- a/train_agents.py
+++ b/train_agents.py
@@ -73,6 +73,12 @@ def train(
     algo_class = PPO
     env = make_env(render_mode=render_mode, max_steps=1000000)
 
+    stats_file = os.path.join(logdir, "ppo_final_stats.npz")
+    if resume_from is not None:
+        stats_path = stats_file if os.path.exists(stats_file) else resume_from.replace(".zip", "_stats.npz")
+        if os.path.exists(stats_path):
+            env.env.load_running_stats_from_file(stats_path)
+
     checkpoint_callback = CheckpointCallback(
         save_freq=10000,
         save_path=os.path.join(logdir, "checkpoints"),
@@ -111,6 +117,7 @@ def train(
         print("Training interrupted. Saving model...")
     finally:
         model.save(os.path.join(logdir, "ppo_final"))
+        env.env.save_running_stats(stats_file)
         env.close()
 
 


### PR DESCRIPTION
## Summary
- preserve running observation statistics for evaluation
- restore running stats when resuming training
- use stored statistics during evaluation to avoid constant actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874158d1d28832290ac3101e94cfed4