### PR TITLE
Replace RunningStats with VecNormalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ mining_simulation/
 - Agregados espaciales: distancias promedio y utilización de flota
 
 **Action Space**:
-- 9 acciones discretas con action masking
+- 9 acciones discretas
 - 0: No-op
 - 1-6: Enviar camión vacío a cada pala
 - 7: Enviar camión cargado al crusher
@@ -285,7 +285,7 @@ python eval.py --from training_logs/best/best_model.zip --mode visual --steps 10
 
 ### **Sistema de Reinforcement Learning**
 - [x] Environment Gymnasium compatible (`MiningEnv`) con observation space de 124 dimensiones
-- [x] Action space discreto (9 acciones) con action masking inteligente
+- [x] Action space discreto (9 acciones)
 - [x] Función de recompensa balanceada: producción + utilización - penalización de colas
 - [x] Script de entrenamiento con PPO
  - [x] Checkpoints automáticos
@@ -373,8 +373,7 @@ def _calculate_reward(self) -> float:
 - **Performance optimized**: Modo headless para entrenamiento RL intensivo
 
 ### **Consideraciones de RL**
-- **Normalización automática**: Observations normalizadas usando running statistics
-- **Action masking**: Solo acciones válidas disponibles en cada timestep
+- **Normalización automática**: Observations normalizadas usando `VecNormalize`
 - **Episode management**: Terminación por producción objetivo (400t) o límite de pasos (800)
 - **Reward engineering**: Balance entre throughput, eficiencia y prevención de deadlocks
 

--- a/docs/rl_env.md
+++ b/docs/rl_env.md
@@ -9,7 +9,7 @@ The observation vector has 54 continuous values:
 - Truck state: task id, load ratio, efficiency and distances for each truck
 - Spatial aggregates: average distances and fleet utilisation statistics
 
-Values are normalised to `[0,1]` using running statistics collected during training.
+Observations are normalised automatically using `VecNormalize` during training and evaluation.
 
 ## Action Space
 A discrete action chooses among nine high level commands:
@@ -17,7 +17,7 @@ A discrete action chooses among nine high level commands:
 1-6. Send an available empty truck to the corresponding shovel
 7. Send a loaded truck to the crusher
 8. Send a loaded truck to the dump
-Invalid actions are masked via the `action_mask` entry in `info`.
+
 
 ## Reward
 The reward is based on incremental production with efficiency bonuses and several penalties:

--- a/research.md
+++ b/research.md
@@ -61,7 +61,7 @@ Recent implementation frameworks support **fleet sizes up to 30,000 agents** wit
 - Clip range: 0.2 for conservative policy updates
 - GAE lambda: 0.95 for bias-variance balance
 
-**Action masking implementation** should provide binary masks for each action dimension, with dynamic mask generation based on current mine state including equipment availability, capacity constraints, and safety protocols. The `get_action_masks()` method should integrate with existing fleet management systems to reflect real-time operational conditions.
+Previously the environment relied on action masking to avoid invalid moves. The latest setup removes this mechanism in favour of simpler policies without masks.
 
 **Multi-agent coordination** should follow the CTDE paradigm with centralized training accessing global mine state while enabling decentralized execution for individual trucks. Implement hierarchical communication protocols with supervisor-level planning, coordinator-level task assignment, and executor-level equipment control.
 


### PR DESCRIPTION
## Summary
- remove RunningStats and action masking from `MiningEnv`
- normalize observations using `VecNormalize`
- update training and evaluation scripts to load/save `VecNormalize` stats
- adjust docs to reference `VecNormalize`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687425843dd88322980dcd0e422a63de