### PR TITLE
Include misdirected material in observation space

### DIFF
--- a/core/fms_manager.py
+++ b/core/fms_manager.py
@@ -284,6 +284,9 @@ class FMSManager:
         # Global state
         obs.append(self.tick_count)
         obs.append(self.crusher.total_processed)
+        # Track material incorrectly routed to provide better feedback for RL
+        obs.append(self.crusher.total_waste_dumped)
+        obs.append(self.dump.total_mineral_dumped)
         available = len([t for t in self.trucks if t.is_available()])
         obs.append(available)
 

--- a/docs/rl_env.md
+++ b/docs/rl_env.md
@@ -5,6 +5,7 @@
 ## Observation Space
 The observation vector has 115 continuous values:
 - Global status: tick, total production and number of available trucks
+- Misdirected material: waste dumped at the crusher and mineral lost at the dump
 - Fixed equipment: queue length and busy flag for crusher, dump and each shovel
 - Truck state: task id, load ratio, efficiency and distances for each truck
 - Spatial aggregates: average distances and fleet utilisation statistics


### PR DESCRIPTION
## Summary
- add `crusher.total_waste_dumped` and `dump.total_mineral_dumped` to the observation vector
- document the new metrics in the environment overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ea5847dc8322bb4d3111e4b50773