### PR TITLE
Remove queue limits in FMS

### DIFF
--- a/core/crusher.py
+++ b/core/crusher.py
@@ -31,9 +31,5 @@ class Crusher:
                 self.current_truck = None
                 
     def request_dump(self, truck):
-        if truck not in self.queue and truck.task == "waiting_dump":
-            self.queue.append(truck)
-            
-    def can_accept_truck(self):
-        """Verifica si el crusher puede aceptar más camiones"""
-        return len(self.queue) < 2
+        """Encola el camión para descarga sin restricciones."""
+        self.queue.append(truck)

--- a/core/dump.py
+++ b/core/dump.py
@@ -29,10 +29,6 @@ class Dump:
                 self.current_truck = None
                 
     def request_dump(self, truck):
-        if truck not in self.queue and truck.task == "waiting_dump":
-            self.queue.append(truck)
-            
-    def can_accept_truck(self):
-        """Verifica si el dump puede aceptar más camiones"""
-        return len(self.queue) < 2
+        """Encola el camión para descarga sin restricciones."""
+        self.queue.append(truck)
 

--- a/core/shovel.py
+++ b/core/shovel.py
@@ -69,10 +69,6 @@ class Shovel:
                     self.timer = self.load_time
                 
     def request_load(self, truck):
-        if truck not in self.queue and truck.task == "waiting_shovel":
-            self.queue.append(truck)
-            
-    def can_accept_truck(self):
-        """Verifica si la pala puede aceptar más camiones"""
-        return len(self.queue) < 3  # Máximo 3 camiones en cola
+        """Encola el camión sin restricciones."""
+        self.queue.append(truck)
 

--- a/core/simulation.py
+++ b/core/simulation.py
@@ -35,28 +35,21 @@ class Simulation:
     # Decision logic (heuristics)
     # ------------------------------------------------------------------
     def _select_dump_destination(self, truck):
-        destination = None
+        """Selecciona destino de descarga sin considerar capacidad."""
         if truck.material_type == 'mineral':
-            if self.crusher.can_accept_truck():
-                destination = 'crusher'
-            elif self.dump.can_accept_truck():
-                destination = 'dump_zone'
-        else:
-            if self.dump.can_accept_truck():
-                destination = 'dump_zone'
-        return destination
+            return 'crusher'
+        return 'dump_zone'
 
     def _find_best_shovel(self):
-        available = [s for s in self.shovels if s.can_accept_truck()]
-        if not available:
+        if not self.shovels:
             return None
 
-        mineral = [s for s in available if s.material_type == 'mineral']
-        waste = [s for s in available if s.material_type == 'waste']
+        mineral = [s for s in self.shovels if s.material_type == 'mineral']
+        waste = [s for s in self.shovels if s.material_type == 'waste']
 
         if mineral and (not waste or self.crusher.total_processed < self.dump.total_dumped):
             return min(mineral, key=lambda s: len(s.queue))
-        return min(available, key=lambda s: len(s.queue))
+        return min(self.shovels, key=lambda s: len(s.queue))
 
     def get_statistics(self):
         return self.manager.get_statistics()


### PR DESCRIPTION
## Summary
- allow unlimited truck queues at crusher, dump and shovels
- remove checks for queue limits from simulation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ee478fb8832284908d55d73e7f4d