### PR TITLE
Add penalty for trucks heading to wrong dump

### DIFF
--- a/core/fms_manager.py
+++ b/core/fms_manager.py
@@ -345,3 +345,17 @@ class FMSManager:
 
         obs = full_obs[:dim]
         return obs.tolist()
+
+    def count_wrong_dump_assignments(self) -> int:
+        """Count trucks currently heading to the wrong dump destination."""
+        count = 0
+        for t in self.trucks:
+            if t.task == 'moving_to_dump' and t.route:
+                destination = t.route[-1]
+                if (
+                    t.material_type == 'mineral' and destination == 'dump_zone'
+                ) or (
+                    t.material_type == 'waste' and destination == 'crusher'
+                ):
+                    count += 1
+        return count

--- a/docs/rl_env.md
+++ b/docs/rl_env.md
@@ -29,8 +29,9 @@ reward = (delta_waste + 2 * delta_mineral)
          - 0.5 * delta_hang_time
          - 2.0 * delta_mineral_lost
          - 1.0 * delta_waste_in_crusher
+         - 1.0 * wrong_assignments
 ```
-This favours mineral production, keeps the fleet working and penalises idle shovels or incorrect dumping of material.
+This favours mineral production, keeps the fleet working and penalises idle shovels, incorrect dumping of material or trucks heading to the wrong destination.
 
 ## Episode Termination
 Episodes end when either a production target or a step limit is reached. By default the environment terminates after accumulating **400t** of total throughput or **800** steps, whichever happens first. These values can be customised via the `max_steps` and `target_production` parameters when creating the environment.

--- a/rl/mining_env.py
+++ b/rl/mining_env.py
@@ -220,6 +220,7 @@ class MiningEnv(gym.Env):
         penalty += 0.5 * delta_hang
         penalty += 2.0 * delta_lost
         penalty += 1.0 * delta_wrong
+        penalty += 1.0 * self.manager.count_wrong_dump_assignments()
         return production + working - penalty
 
     def _get_observation(self) -> np.ndarray:


### PR DESCRIPTION
## Summary
- detect trucks going to an incorrect dump target
- penalize misassigned trucks when computing reward
- document the new penalty in MiningEnv docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f95c754c832298a176891951320c