### PR TITLE
Add wrong dump penalty to observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ mining_simulation/
 
 ### Environment: `MiningEnv`
 
-**Observation Space** (115 dimensiones normalizadas):
+**Observation Space** (116 dimensiones normalizadas):
  - Estructura jerárquica local/global/comunicación/temporal
  - Estado global: tick, producción total, camiones disponibles
  - Colas y estado de crusher, dump y palas
- - Estado detallado de cada camión (task, carga, eficiencia, distancias)
- - Agregados espaciales: distancias promedio y utilización de flota
+- Estado detallado de cada camión (task, carga, eficiencia, distancias)
+- Agregados espaciales: distancias promedio, utilización de flota y penalización por rutas erróneas
 
 **Action Space**:
 - Espacio multidiscreto `[id_camión, comando]`
@@ -285,7 +285,7 @@ python eval.py --from training_logs/best/best_model.zip --mode visual --steps 10
 - [x] Leyenda completa y controles interactivos
 
 -### **Sistema de Reinforcement Learning**
-- [x] Environment Gymnasium compatible (`MiningEnv`) con observation space optimizado de 115 dimensiones
+- [x] Environment Gymnasium compatible (`MiningEnv`) con observation space optimizado de 116 dimensiones
 - [x] Action space multidiscreto `[id_camión, comando]`
 - [x] Función de recompensa balanceada: producción + utilización - penalización de colas
 - [x] Script de entrenamiento con PPO

--- a/docs/rl_env.md
+++ b/docs/rl_env.md
@@ -3,12 +3,12 @@
 `MiningEnv` is a Gymnasium-compatible environment wrapping the `FMSManager` simulation.
 
 ## Observation Space
-The observation vector has 115 continuous values:
+The observation vector has 116 continuous values:
 - Global status: tick, total production and number of available trucks
 - Misdirected material: waste dumped at the crusher and mineral lost at the dump
 - Fixed equipment: queue length and busy flag for crusher, dump and each shovel
 - Truck state: task id, load ratio, efficiency and distances for each truck
-- Spatial aggregates: average distances and fleet utilisation statistics
+- Spatial aggregates: average distances, fleet utilisation statistics and wrong dump penalty
 
 Observations are normalised automatically using `VecNormalize` during training and evaluation.
 

--- a/rl/mining_env.py
+++ b/rl/mining_env.py
@@ -48,7 +48,8 @@ class MiningEnv(gym.Env):
             self._init_pygame()
 
         # Optimized observation space with material type info
-        self.obs_dim = 115
+        # One extra dimension for the wrong dump penalty
+        self.obs_dim = 116
         self.observation_space = gym.spaces.Box(
             low=-np.inf,
             high=np.inf,
@@ -101,7 +102,8 @@ class MiningEnv(gym.Env):
         # Recreate manager to reset state
         self.manager = FMSManager()
         # Recompute observation space in case fleet size changed
-        self.obs_dim = 115
+        # One extra dimension for the wrong dump penalty
+        self.obs_dim = 116
         self.observation_space = gym.spaces.Box(
             low=-np.inf,
             high=np.inf,
@@ -226,9 +228,11 @@ class MiningEnv(gym.Env):
         return production + working - penalty
 
     def _get_observation(self) -> np.ndarray:
+        wrong_dump_penalty = float(self.manager.count_wrong_dump_assignments())
         raw_obs = np.array(
-            self.manager.get_optimized_observation_vector(self.obs_dim),
+            self.manager.get_optimized_observation_vector(self.obs_dim - 1),
             dtype=np.float32,
         )
-        return raw_obs
+        obs = np.concatenate([raw_obs, [wrong_dump_penalty]]).astype(np.float32)
+        return obs
 


### PR DESCRIPTION
## Summary
- extend observation space in `MiningEnv` by adding wrong dump penalty
- document new 116-dim space in README and RL env docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876fb2aebd083229f1aede2487ee985