### PR TITLE
Add detailed dumping metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ Métricas disponibles:
 - `rollout/utilization`: Utilización de la flota
 - `rollout/ep_rew_mean`: Recompensa promedio por episodio
 - `rollout/ep_len_mean`: Duración promedio de episodios
+- `rollout/mineral_crusher`: Mineral descargado en chancadora
+- `rollout/mineral_dump`: Mineral descargado en botadero
+- `rollout/waste_in_crusher`: Desmonte descargado en chancadora
+- `rollout/waste_dump`: Desmonte descargado en botadero
+- `rollout/wrong_assignments`: Camiones asignados incorrectamente
 
 ## 📊 Configuración del Sistema
 

--- a/rl/mining_env.py
+++ b/rl/mining_env.py
@@ -168,6 +168,11 @@ class MiningEnv(gym.Env):
             "lost_mineral": self.manager.dump.total_mineral_dumped,
             "waste_in_crusher": self.manager.crusher.total_waste_dumped,
             "hang_time": sum(s.hang_time for s in self.manager.shovels),
+            # Additional metrics for detailed monitoring
+            "mineral_in_crusher": self.manager.crusher.total_processed,
+            "mineral_in_dump": self.manager.dump.total_mineral_dumped,
+            "waste_in_dump": self.manager.dump.total_dumped,
+            "wrong_assignments": self.manager.count_wrong_dump_assignments(),
         }
         return obs, reward, terminated, truncated, info
 

--- a/train_agents.py
+++ b/train_agents.py
@@ -39,6 +39,11 @@ class TensorboardMetricsCallback(BaseCallback):
             lost = info.get("lost_mineral")
             wrong = info.get("waste_in_crusher")
             hang = info.get("hang_time")
+            # New detailed metrics
+            mineral_crusher = info.get("mineral_in_crusher")
+            mineral_dump = info.get("mineral_in_dump")
+            waste_dump = info.get("waste_in_dump")
+            wrong_assign = info.get("wrong_assignments")
             if throughput is not None:
                 self.logger.record("rollout/throughput", float(throughput))
             if util is not None:
@@ -49,6 +54,14 @@ class TensorboardMetricsCallback(BaseCallback):
                 self.logger.record("rollout/waste_in_crusher", float(wrong))
             if hang is not None:
                 self.logger.record("rollout/hang_time", float(hang))
+            if mineral_crusher is not None:
+                self.logger.record("rollout/mineral_crusher", float(mineral_crusher))
+            if mineral_dump is not None:
+                self.logger.record("rollout/mineral_dump", float(mineral_dump))
+            if waste_dump is not None:
+                self.logger.record("rollout/waste_dump", float(waste_dump))
+            if wrong_assign is not None:
+                self.logger.record("rollout/wrong_assignments", float(wrong_assign))
 
         if self.checkpoint_callback is not None:
             ckpt_cb = self.checkpoint_callback


### PR DESCRIPTION
## Summary
- log extra dumping metrics in MiningEnv info
- expose new metrics via TensorBoard callback
- document additional TensorBoard metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770001ed44832287a0614581b099fb