### PR TITLE
Add multi-agent evaluation & visualization support

### DIFF
--- a/core/fms_manager.py
+++ b/core/fms_manager.py
@@ -1,4 +1,4 @@
-from numpy._typing._array_like import NDArray
+from numpy.typing import NDArray
 from core.mine_map import MineMap
 from core.truck import Truck
 from core.shovel import Shovel

--- a/multi_agent/__init__.py
+++ b/multi_agent/__init__.py
@@ -4,10 +4,12 @@ from .ma_fms_manager import MultiAgentFMSManager
 from .ma_mining_env import MiningParallelEnv
 from .ma_config import get_default_config
 from .ma_train import train
+from .ma_eval import evaluate
 
 __all__ = [
     "MultiAgentFMSManager",
     "MiningParallelEnv",
     "get_default_config",
     "train",
+    "evaluate",
 ]

--- a/multi_agent/ma_config.py
+++ b/multi_agent/ma_config.py
@@ -5,12 +5,12 @@ from ray.rllib.algorithms.mappo import MAPPOConfig
 from .ma_mining_env import MiningParallelEnv
 
 
-def get_default_config() -> MAPPOConfig:
+def get_default_config(render_mode: str = "headless") -> MAPPOConfig:
     """Return a basic MAPPO configuration for the mining environment."""
-    env = MiningParallelEnv()
+    env = MiningParallelEnv(render_mode=render_mode)
     config = (
         MAPPOConfig()
-        .environment(env=MiningParallelEnv)
+        .environment(env=MiningParallelEnv, env_config={"render_mode": render_mode})
         .framework("torch")
         .rollouts(num_rollout_workers=0)
         .training(train_batch_size=4000)

--- a/multi_agent/ma_eval.py
+++ b/multi_agent/ma_eval.py
@@ -1,0 +1,42 @@
+import argparse
+from typing import Dict
+
+from ray.rllib.algorithms.mappo import MAPPO
+
+from .ma_config import get_default_config
+
+
+def evaluate(checkpoint: str, render_mode: str = "headless", steps: int = 100) -> None:
+    """Load a MAPPO checkpoint and run a short evaluation."""
+    config = get_default_config(render_mode)
+    algo = MAPPO(config=config.to_dict())
+    algo.restore(checkpoint)
+
+    env = algo.workers.local_worker().env
+    obs, _ = env.reset()
+    for _ in range(steps):
+        actions: Dict[str, int] = {}
+        for agent_id, agent_obs in obs.items():
+            action, _, _ = algo.compute_single_action(agent_obs, policy_id="shared_policy")
+            actions[agent_id] = int(action)
+        obs, _, term, trunc, _ = env.step(actions)
+        if env.render_mode == "visual":
+            env.render()
+        if term.get("__all__") or trunc.get("__all__"):
+            obs, _ = env.reset()
+
+    env.close()
+    algo.stop()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--from", dest="checkpoint", required=True)
+    parser.add_argument("--mode", choices=["headless", "visual"], default="headless")
+    parser.add_argument("--steps", type=int, default=100)
+    args = parser.parse_args()
+    evaluate(args.checkpoint, render_mode=args.mode, steps=args.steps)
+
+
+if __name__ == "__main__":
+    main()

--- a/multi_agent/ma_train.py
+++ b/multi_agent/ma_train.py
@@ -7,10 +7,15 @@ from torch.utils.tensorboard import SummaryWriter
 from .ma_config import get_default_config
 
 
-def train(num_iters: int, logdir: str, resume_from: str | None = None):
+def train(
+    num_iters: int,
+    logdir: str,
+    resume_from: str | None = None,
+    render_mode: str = "headless",
+):
     """Train a MAPPO agent and log metrics to TensorBoard."""
 
-    config = get_default_config()
+    config = get_default_config(render_mode)
     if resume_from:
         algo = MAPPO(config=config.to_dict())
         algo.restore(resume_from)
@@ -47,8 +52,14 @@ def main():
     parser.add_argument("--iters", type=int, default=1)
     parser.add_argument("--logdir", type=str, default="ma_training_logs")
     parser.add_argument("--resume", type=str, default=None)
+    parser.add_argument(
+        "--mode",
+        choices=["headless", "visual"],
+        default="headless",
+        help="Training mode: with or without visualization",
+    )
     args = parser.parse_args()
-    train(args.iters, args.logdir, args.resume)
+    train(args.iters, args.logdir, args.resume, args.mode)
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+import unittest
+
+from multi_agent.ma_train import train
+from multi_agent.ma_eval import evaluate
+
+class MultiAgentPipelineTest(unittest.TestCase):
+    def test_train_headless(self):
+        logdir = "ma_test_logs_headless"
+        train(num_iters=1, logdir=logdir, render_mode="headless")
+        ckpt = os.path.join(logdir, "checkpoint_000001")
+        self.assertTrue(os.path.exists(ckpt))
+        shutil.rmtree(logdir)
+
+    def test_train_visual_and_eval(self):
+        os.environ["SDL_VIDEODRIVER"] = "dummy"
+        logdir = "ma_test_logs_visual"
+        train(num_iters=1, logdir=logdir, render_mode="visual")
+        ckpt_dir = os.path.join(logdir, "checkpoint_000001")
+        ckpt_file = os.path.join(ckpt_dir, "checkpoint-000001")
+        self.assertTrue(os.path.exists(ckpt_file))
+        evaluate(ckpt_file, render_mode="headless", steps=1)
+        evaluate(ckpt_file, render_mode="visual", steps=1)
+        shutil.rmtree(logdir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable visualization option for `MiningParallelEnv`
- expose render mode in MAPPO config and training script
- add evaluation script for multi-agent models
- adjust numpy typing import
- provide tests for multi-agent training and evaluation

## Testing
- `pytest -q tests/test_multi_agent.py::MultiAgentPipelineTest::test_train_headless` *(fails: ModuleNotFoundError: No module named 'multi_agent')*

------
https://chatgpt.com/codex/tasks/task_e_6882a01dbaac83229229b413023b9d85